### PR TITLE
gccgo compatibility

### DIFF
--- a/type_map.go
+++ b/type_map.go
@@ -1,3 +1,5 @@
+// +build !gccgo
+
 package reflect2
 
 import (


### PR DESCRIPTION
Lots of projects use `reflect2.TypeOf`, but they can't be built with gccgo because of the way `reflect2.TypeByName` is implemented.  Here's a slight modification to have gccgo skip `type_map.go`.

Projects that use `reflect2.TypeByName` will still be unbuildable by gccgo, but all the rest of reflect2 should work.

This fixes #6  and #9 