### PR TITLE
fix possible memory confusion in unsafe slice cast

### DIFF
--- a/reflect2.go
+++ b/reflect2.go
@@ -288,11 +288,12 @@ func NoEscape(p unsafe.Pointer) unsafe.Pointer {
 }
 
 func UnsafeCastString(str string) []byte {
+	bytes := make([]byte, 0)
 	stringHeader := (*reflect.StringHeader)(unsafe.Pointer(&str))
-	sliceHeader := &reflect.SliceHeader{
-		Data: stringHeader.Data,
-		Cap: stringHeader.Len,
-		Len: stringHeader.Len,
-	}
-	return *(*[]byte)(unsafe.Pointer(sliceHeader))
+	sliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&bytes))
+	sliceHeader.Data = stringHeader.Data
+	sliceHeader.Cap = stringHeader.Len
+	sliceHeader.Len = stringHeader.Len
+	runtime.KeepAlive(str)
+	return bytes
 }


### PR DESCRIPTION
I found an incorrect cast from `string` to `[]byte` in `reflect2.go`. The problem is that when `reflect.SliceHeader` is created as a composite literal (instead of deriving it from an actual slice by cast), then the Go garbage collector will not treat its `Data` field as a reference. If the GC runs just between creating the `SliceHeader` and casting it into the final, real `[]byte` slice, then the underlying data might have been collected already, effectively making the returned `[]byte` slice a dangling pointer.

This has a low probability to occur, but projects that import this library might still use it in a code path that gets executed a lot, thus increasing the probability to happen. Depending on the memory layout at the time of the GC run, this could potentially create an information leak vulnerability.

This PR changes the function to create the `reflect.SliceHeader` from an actual slice by first instantiating the return value.